### PR TITLE
Introduce replaceParamBy TypeInfo option, to allow Object to mapped t…

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -2,7 +2,7 @@ import StringBuilder = require('string-builder');
 
 export type Imports = { [moduleName: string]: string[] }
 
-export type TypeInfo = { replaceBy?: string, definedIn?: string, code?: string }
+export type TypeInfo = { replaceBy?: string, replaceParamBy?: string, definedIn?: string, code?: string }
 export type TypeInfos = { [typeName: string]: TypeInfo }
 
 export const baseTypes: TypeInfos = {
@@ -10,7 +10,7 @@ export const baseTypes: TypeInfos = {
   string: {},
   number: {},
   any: {},
-  Object: { replaceBy: 'object' },
+  Object: { replaceBy: '{ [key: string]: any }', replaceParamBy: 'object' },
   this: {},
   null: {},
   undefined: {},
@@ -79,13 +79,17 @@ export class GenEnv {
     return typeInfo && typeInfo.code
   }
 
-  resolveTypeName(rawName: string): string {
+  resolveTypeName(rawName: string, isParam: boolean): string {
     const typeInfo = this.typeInfos[rawName]
     if (/^\"[^\"]*\"$/.test(rawName)) {
       return rawName
     }
     if (typeInfo) {
-      const name = typeof typeInfo.replaceBy == 'string' ? typeInfo.replaceBy : rawName
+      const name = typeof typeInfo.replaceBy == 'string'
+        ? isParam
+          ? typeInfo.replaceParamBy || typeInfo.replaceBy
+          : typeInfo.replaceBy
+        : rawName
       if (typeof typeInfo.definedIn == 'string' && typeInfo.definedIn != this.currModuleName) {
         const importsFromModule = this.imports[typeInfo.definedIn] || []
         if (importsFromModule.indexOf(name) == -1) importsFromModule.push(name)

--- a/src/gendeclaration.ts
+++ b/src/gendeclaration.ts
@@ -103,7 +103,7 @@ export function itemDef(env: GenEnv, decl: Declaration, name: string, exportDecl
       env.append(customCode)
     } else {
       if (exportDecl) env.append("export ")
-      classDef(env, decl, env.resolveTypeName(name))
+      classDef(env, decl, env.resolveTypeName(name, false))
     }
   } else {
     if (exportDecl) env.append("export ")

--- a/test/function.spec.ts
+++ b/test/function.spec.ts
@@ -34,6 +34,12 @@ describe('should add function definition', () => {
       env.sb.toString().should.equal("() => string | (() => void) | null | undefined")
     })
 
+    it('Object', () => {
+      const item: FunctionType = { type: "Function", params: [], returns: { type: "Object" } }
+      functionDef(env, item);
+      env.sb.toString().should.equal("() => { [key: string]: any }")
+    });
+
   });
 
   describe('with parameters', () => {

--- a/test/object.spec.ts
+++ b/test/object.spec.ts
@@ -21,6 +21,6 @@ describe('should add object definition', () => {
       properties: { prop1: { type: "string" }, prop2: { type: "Object" } }
     };
     objectDef(env, item);
-    env.sb.toString().should.equal("{ prop1: string, prop2: object }")
+    env.sb.toString().should.equal("{ prop1: string, prop2: { [key: string]: any } }")
   });
 });

--- a/test/type.spec.ts
+++ b/test/type.spec.ts
@@ -73,7 +73,7 @@ describe('when adding type definition', () => {
   it('should handle an object with unknown properties', () => {
     const item = { type: "Object", };
     typeDef(env, item);
-    env.sb.toString().should.equal("object")
+    env.sb.toString().should.equal("{ [key: string]: any }")
   });
 
   it('should handle objects with a known value type', () => {


### PR DESCRIPTION
…o a different name if it is a parameter.

Resolves #2.

Interested in you have an idea for a different approach @timjb 

The goal with this was to emit `object` in places where it's safe (I determined that to be function parameters), and `{ [key: string]: any }` everywhere else.