### PR TITLE
Refactor: Remove StringBuilder, use LF line endings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,7 @@
   "homepage": "https://github.com/bradleyayers/getdocs2ts#readme",
   "dependencies": {
     "builddocs": "^0.1.3",
-    "debug": "^2.6.1",
-    "getdocs": "^0.5.0",
-    "mkdirp": "0.5.1",
-    "mold-template": "^2.0.1",
-    "sinon": "^1.17.7",
-    "typescript": "^2.3.3"
+    "mkdirp": "0.5.1"
   },
   "files": [
     "out/src"
@@ -41,12 +36,9 @@
   "devDependencies": {
     "@types/mocha": "^2.2.39",
     "@types/chai": "^3.4.35",
-    "@types/chai-as-promised": "^0.0.29",
-    "@types/sinon": "^1.16.35",
-    "@types/debug": "0.0.29",
     "@types/node": "^7.0.5",
     "mocha": "^3.2.0",
     "chai": "^3.5.0",
-    "chai-as-promised": "^6.0.0"
+    "typescript": "^2.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "mkdirp": "0.5.1",
     "mold-template": "^2.0.1",
     "sinon": "^1.17.7",
-    "string-builder": "^0.1.4",
     "typescript": "^2.3.3"
   },
   "files": [

--- a/src/build.ts
+++ b/src/build.ts
@@ -32,7 +32,7 @@ export default function (
     const mod = moduleContents[module.name]
     let sb = moduleDef(mod, module.name, typeInfos);
     mkdirpIfNotExists(path.dirname(module.outFile))
-    fs.writeFileSync(module.outFile, (module.header || '') + sb.toString());
+    fs.writeFileSync(module.outFile, (module.header || '') + sb.join("\n"));
   }
 
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -4,7 +4,7 @@ const mkdirp = require('mkdirp');
 const path = require('path')
 
 import {ModuleContents} from "./types"
-import {TypeInfos, baseTypes, mergeTypeInfos} from "./env"
+import {TypeInfos, mergeTypeInfos} from "./env"
 import {exportedTypeInfos} from "./exports"
 import moduleDef from "./genmodule";
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,3 @@
-import StringBuilder = require('string-builder');
-
 export type Imports = { [moduleName: string]: string[] }
 
 export type TypeInfo = { replaceBy?: string, definedIn?: string, code?: string }
@@ -58,23 +56,13 @@ export class GenEnv {
   readonly imports: Imports
   private currModuleName: string
   private typeInfos: TypeInfos
-  readonly sb: StringBuilder
-  private indentation: string
-  private firstInLine: boolean
 
   private static warnedAbout: { [name: string]: true } = {}
 
-  constructor(currModuleName: string, imports: Imports, typeInfos: TypeInfos, sb: StringBuilder, indentation: string = "", firstInLine: boolean = true) {
+  constructor(currModuleName: string, imports: Imports, typeInfos: TypeInfos) {
     this.currModuleName = currModuleName
     this.imports = imports
     this.typeInfos = typeInfos
-    this.sb = sb
-    this.indentation = indentation
-    this.firstInLine = firstInLine
-  }
-
-  indent(): GenEnv {
-    return new GenEnv(this.currModuleName, this.imports, this.typeInfos, this.sb, this.indentation + "  ", this.firstInLine)
   }
 
   customCodeFor(rawName: string): string | undefined {
@@ -102,24 +90,8 @@ export class GenEnv {
     }
     return rawName
   }
-
-  append(str: string) {
-    if (str == "") return
-    if (this.firstInLine) this.sb.append(this.indentation)
-    this.firstInLine = false
-    this.sb.append(str)
-  }
-
-  appendLine(str: string) {
-    if (str != "") {
-      this.sb.appendLine(this.indentation + str)
-    } else {
-      this.sb.appendLine(str)
-    }
-    this.firstInLine = true
-  }
 } 
 
 export function emptyEnvForTests(additionalTypes: TypeInfos = {}): GenEnv {
-  return new GenEnv("test", {}, mergeTypeInfos(baseTypes, additionalTypes), new StringBuilder())
+  return new GenEnv("test", {}, mergeTypeInfos(baseTypes, additionalTypes))
 }

--- a/src/gendeclaration.ts
+++ b/src/gendeclaration.ts
@@ -1,5 +1,5 @@
 import {GenEnv} from "./env"
-import {FunctionType, Type, isFunction, isObject, Declaration, ClassOrInterfaceDeclaration, OtherDeclaration, isClassOrInterfaceDeclaration} from "./types";
+import {FunctionType, isFunction, Declaration, ClassOrInterfaceDeclaration, OtherDeclaration, isClassOrInterfaceDeclaration} from "./types";
 import { typeDef, functionParamsDef, functionReturnDef, unionWith, nullType, undefinedType } from "./gentype";
 
 function functionDeclarationDef(env: GenEnv, item: FunctionType): string {

--- a/src/gendeclaration.ts
+++ b/src/gendeclaration.ts
@@ -2,20 +2,46 @@ import {GenEnv} from "./env"
 import {FunctionType, Type, isFunction, isObject, Declaration, ClassOrInterfaceDeclaration, OtherDeclaration, isClassOrInterfaceDeclaration} from "./types";
 import { typeDef, functionParamsDef, functionReturnDef, unionWith, nullType, undefinedType } from "./gentype";
 
-function functionDeclarationDef(env: GenEnv, item: FunctionType) {
-  functionParamsDef(env, item.params || []);
-  env.append(": ")
-  functionReturnDef(env, item.returns);
+function functionDeclarationDef(env: GenEnv, item: FunctionType): string {
+  return functionParamsDef(env, item.params || []) + ": " + functionReturnDef(env, item.returns)
 }
 
-function jsDocComment(env: GenEnv, comment?: string) {
-  if (comment == undefined) return
-  env.append("/**")
-  comment.trim().split('\n').forEach((line) => {
-    env.appendLine(" * " + line.trim());
-  })
-  env.appendLine(" */")
-  env.appendLine("")
+function jsDocComment(env: GenEnv, comment?: string): string[] {
+  if (comment == undefined) return []
+  return ([] as string[]).concat(
+    ["/**"],
+    comment.trim().split('\n').map((line) => " * " + line.trim()),
+    [" */"]
+  )
+}
+
+function miscDefBody(
+  env: GenEnv,
+  type: OtherDeclaration & { optional?: boolean },
+  name: string,
+  options: { isInlineProp: boolean }
+): string {
+  if (isFunction(type) && !type.optional) {
+    const isConstructor = typeof type.id == "string" && /\.constructor$/.test(type.id);
+    if (isConstructor) {
+      return "constructor" + functionParamsDef(env, type.params || [])
+    } else {
+      return (options.isInlineProp ? "" : "function ") + name + functionDeclarationDef(env, type)
+    }
+  } else if (options.isInlineProp) {
+    if (type.type) {
+      if (type.optional) {
+        return name + "?: " + typeDef(env, unionWith(type, nullType)) + ";"
+      } else {
+        return name + ": " + typeDef(env, type) + ";"
+      }
+    } else {
+      return name + ";"
+    }
+  } else {
+    return "let " + name + 
+      (type.type ? ": " + typeDef(env, type.optional ? unionWith(type, nullType, undefinedType) : type) : "")
+  }
 }
 
 export function miscDef(
@@ -23,102 +49,50 @@ export function miscDef(
   type: OtherDeclaration & { optional?: boolean },
   name: string,
   options: { isInlineProp: boolean, prefix?: string }
-) {
+): string[] {
 
-  jsDocComment(env, type.description);
-  env.append(options.prefix || "")
-
-  if (isFunction(type) && !type.optional) {
-    const isConstructor = typeof type.id == "string" && /\.constructor$/.test(type.id);
-    if (isConstructor) {
-      env.append("constructor")
-      functionParamsDef(env, type.params || []);
-    } else {
-      if(!options.isInlineProp) env.append("function ")
-      env.append(name)
-      functionDeclarationDef(env, type);
-    }
-  } else if (options.isInlineProp) {
-    env.append(name)
-    if (type.type) {
-      if (type.optional) {
-        env.append("?: ")
-        typeDef(env, unionWith(type, nullType))
-      } else {
-        env.append(": ")
-        typeDef(env, type)
-      }
-    }
-    env.append(";")
-  } else {
-    env.append("let " + name)
-    if (type.type) {
-      env.append(": ")
-      typeDef(env, type.optional ? unionWith(type, nullType, undefinedType) : type)
-    }
-  }
+  return ([] as string[]).concat(
+    jsDocComment(env, type.description),
+    [(options.prefix || "") + miscDefBody(env, type, name, options)]
+  )
 
 }
 
-export function classDef(env: GenEnv, decl: ClassOrInterfaceDeclaration, name: string, exportDecl: boolean = false) {
-  jsDocComment(env, decl.description)
+export function classDef(
+  env: GenEnv,
+  decl: ClassOrInterfaceDeclaration,
+  name: string,
+  exportDecl: boolean = false
+): string[] {
+  const typeParams = decl.typeParams ? "<" + decl.typeParams.map((typeParam) => typeDef(env, typeParam)).join(", ") + ">" : ""
+  const extendsClause = decl.extends ? " extends " + typeDef(env, decl.extends) : ""
+  const header = decl.type + " " + name + typeParams + extendsClause
 
-  if (exportDecl) env.append("export ")
-  env.append(decl.type + " " + name + " ")
+  const properties = decl.properties || {}
+  const staticProperties = decl.staticProperties || {}
+  const decls = ([] as string[]).concat(
+    ("constructor" in decl && !(decl.constructor instanceof Function))
+      ? miscDef(env, decl.constructor, name, { isInlineProp: false })
+      : [],
+    ...Object.keys(properties).map((prop) => miscDef(env, properties[prop], prop, { isInlineProp: true })),
+    ...Object.keys(staticProperties).map((prop) => miscDef(env, staticProperties[prop], prop, { isInlineProp: true, prefix: "static " }))
+  )
 
-  if (decl.typeParams) {
-    env.append("<")
-    for(let i in decl.typeParams) {
-      if (i != "0"){
-        env.append(", ")
-      }
-
-      typeDef(env, decl.typeParams[i]);
-    }
-    env.append("> ")
-  }
-
-  if(decl.extends) {
-    env.append("extends ")
-    typeDef(env, decl.extends);
-    env.append(" ")
-  }
-
-  env.append("{")
-
-  const indented = env.indent();
-
-  if ("constructor" in decl && !(decl.constructor instanceof Function)) {
-    indented.appendLine("")
-    miscDef(indented, decl.constructor, name, { isInlineProp: false });
-  }
-
-  if (decl.properties) {
-    for (let prop in decl.properties) {
-      indented.appendLine("")
-      miscDef(indented, decl.properties[prop], prop, { isInlineProp: true });
-    }
-  }
-
-  if (decl.staticProperties) {
-    for (let prop in decl.staticProperties) {
-      indented.appendLine("")
-      miscDef(indented, decl.staticProperties[prop], prop, { isInlineProp: true, prefix: "static " });
-    }
-  }
-
-  env.appendLine("}")
+  return ([] as string[]).concat(
+    jsDocComment(env, decl.description),
+    [(exportDecl ? "export " : "") + header + " {"],
+    decls.map((s) => "  " + s),
+    ["}"]
+  )
 }
 
-export function itemDef(env: GenEnv, decl: Declaration, name: string, exportDecl: boolean = false) {
-  if(isClassOrInterfaceDeclaration(decl)) {
+export function itemDef(env: GenEnv, decl: Declaration, name: string, exportDecl: boolean = false): string[] {
+  if (isClassOrInterfaceDeclaration(decl)) {
     const customCode: string | undefined = env.customCodeFor(name)
     if (typeof customCode == 'string') {
-      env.append(customCode)
-    } else {
-      classDef(env, decl, env.resolveTypeName(name), exportDecl)
+      return customCode.split("\n")
     }
-  } else {
-    miscDef(env, decl, name, { isInlineProp: false, prefix: exportDecl ? "export " : "" })
+    return classDef(env, decl, env.resolveTypeName(name), exportDecl)
   }
+  return miscDef(env, decl, name, { isInlineProp: false, prefix: exportDecl ? "export " : "" })
 }

--- a/src/gentype.ts
+++ b/src/gentype.ts
@@ -79,7 +79,7 @@ function unionDef(env: GenEnv, typeParams: Type[], addParens: boolean = false): 
   }
 }
 
-function otherDef(env: GenEnv, type: OtherType) {
+function otherDef(env: GenEnv, type: OtherType): string {
   if (type.typeParams) {
     return env.resolveTypeName(type.type) +
       "<" + type.typeParams.map((param) => typeDef(env, param)).join(', ') + ">"
@@ -88,7 +88,7 @@ function otherDef(env: GenEnv, type: OtherType) {
   }
 }
 
-export function typeDef(env: GenEnv, item: Type, addParens: boolean = false) {
+export function typeDef(env: GenEnv, item: Type, addParens: boolean = false): string {
   if (types.isFunction(item)) {
     return parenthesize(addParens, functionDef(env, item))
   } else if (types.isArray(item)) {

--- a/src/gentype.ts
+++ b/src/gentype.ts
@@ -2,37 +2,33 @@ import {GenEnv} from "./env"
 import {Type, FunctionType, ObjectType, Parameter, OtherType} from "./types";
 import * as types from "./types";
 
-export function functionParamsDef(env: GenEnv, params: Parameter[]) {
-  env.append("(")
-
+export function functionParamsDef(env: GenEnv, params: Parameter[]): string {
   let dummyNameCounter = 0;
-  params.forEach((param, i) => {
-    if(i > 0) env.append(", ")
+  const paramStrs = params.map((param, i) => {
+    let paramStr = '';
     if(param.rest) {
-      env.append("...")
+      paramStr += "..."
     }
 
-    if (param.name) env.append(param.name)
+    if (param.name) paramStr += param.name
     else {
-      env.append("p")
-      if(params.length > 1) env.append((++dummyNameCounter).toString())
+      paramStr += "p"
+      if(params.length > 1) paramStr += (++dummyNameCounter).toString()
     }
     if (param.optional) {
       if (params.slice(i).filter(p => !(p.rest || p.optional)).length == 0) {
         // only optional and rest parameters follow
-        env.append("?: ")
-        typeDef(env, param)
+        paramStr += "?: " + typeDef(env, param)
       } else {
-        env.append(": ")
-        typeDef(env, unionWith(param, undefinedType))
+        paramStr += ": " + typeDef(env, unionWith(param, undefinedType))
       }
     } else {
-      env.append(": ")
-      typeDef(env, param)
+      paramStr += ": " + typeDef(env, param)
     }
+    return paramStr
   })
 
-  env.append(")")
+  return "("+paramStrs.join(', ')+")"
 }
 
 export function unionWith(t: Type, ...ts: Type[]): Type {
@@ -45,92 +41,69 @@ export function unionWith(t: Type, ...ts: Type[]): Type {
 export const undefinedType: Type = { type: "undefined" };
 export const nullType: Type = { type: "null" };
 
-export function functionReturnDef(env: GenEnv, type: types.ReturnType | undefined) {
-  if(type) {
-    typeDef(env, type.optional ? unionWith(type, nullType, undefinedType) : type)
-  } else {
-    env.append("void")
+export function functionReturnDef(env: GenEnv, type: types.ReturnType | undefined): string {
+  if (type) {
+    return typeDef(env, type.optional ? unionWith(type, nullType, undefinedType) : type)
   }
+  return "void"
 }
 
-export function functionDef(env: GenEnv, item: FunctionType) {
-  functionParamsDef(env, item.params || []);
-  env.append(" => ")
-  functionReturnDef(env, item.returns);
+export function functionDef(env: GenEnv, item: FunctionType): string {
+  return functionParamsDef(env, item.params || []) + " => " + functionReturnDef(env, item.returns);
 }
 
-export function objectDef(env: GenEnv, item: ObjectType) {
-  env.append("{ ")
-  
-  let first: boolean = true;
-  for (let name in item.properties) {
+export function objectDef(env: GenEnv, item: ObjectType): string {
+  const propStrs = Object.keys(item.properties).map((name) => {
     const prop = item.properties[name]
-    if (!first) env.append(", ")
-    first = false;
-    env.append(name)
     if (prop.optional) {
-      env.append("?: ")
-      typeDef(env, unionWith(prop, nullType))
+      return name + "?: " + typeDef(env, unionWith(prop, nullType))
     } else {
-      env.append(": ")
-      typeDef(env, prop)
+      return name + ": " + typeDef(env, prop)
     }
-  }
+  })
 
-  env.append(" }")
+  return "{ " + propStrs.join(", ") + " }"
 }
 
-function unionDef(env: GenEnv, typeParams: Type[], addParens: boolean = false) {
+function parenthesize(doIt: boolean, str: string) {
+  return doIt ? "("+str+")" : str
+}
+
+function unionDef(env: GenEnv, typeParams: Type[], addParens: boolean = false): string {
   if (typeParams.length == 0) {
-    env.append("never")
+    return "never"
   } else if (typeParams.length == 1) {
-    typeDef(env, typeParams[0], addParens)
+    return typeDef(env, typeParams[0], addParens)
   } else {
-    if (addParens) env.append("(")
-    for (let i = 0; i < typeParams.length; i++) {
-      if (i > 0) env.append(" | ")
-      typeDef(env, typeParams[i], true)
-    }
-    if (addParens) env.append(")")
+    return parenthesize(addParens, typeParams.map((typeParam) => typeDef(env, typeParam, true)).join(' | '))
   }
 }
 
 function otherDef(env: GenEnv, type: OtherType) {
-  env.append(env.resolveTypeName(type.type))
-
   if (type.typeParams) {
-    env.append("<")
-    for (let i = 0; i < type.typeParams.length; i++) {
-      if (i > 0) env.append(", ")
-      typeDef(env, type.typeParams[i])
-    }
-    env.append(">")
+    return env.resolveTypeName(type.type) +
+      "<" + type.typeParams.map((param) => typeDef(env, param)).join(', ') + ">"
+  } else {
+    return env.resolveTypeName(type.type)
   }
 }
 
 export function typeDef(env: GenEnv, item: Type, addParens: boolean = false) {
   if (types.isFunction(item)) {
-    if (addParens) env.append("(")
-    functionDef(env, item)
-    if (addParens) env.append(")")
+    return parenthesize(addParens, functionDef(env, item))
   } else if (types.isArray(item)) {
     const elemType = item.typeParams[0];
-    typeDef(env, elemType, true);
-    env.append("[]");
+    return typeDef(env, elemType, true) + "[]";
   } else if (types.isObject(item)) {
-    objectDef(env, item)
+    return objectDef(env, item)
   } else if (item.type == "union") {
-    unionDef(env, item.typeParams || [], addParens)
+    return unionDef(env, item.typeParams || [], addParens)
   } else if (item.type == "Object" && item.typeParams && item.typeParams.length == 1) {
     const valueType = item.typeParams[0];
-    env.append("{ [name: string]: ")
-    typeDef(env, valueType)
-    env.append(" }")
+    return "{ [name: string]: " + typeDef(env, valueType) + " }"
   } else if (item.type == "constructor" && item.typeParams && item.typeParams.length == 1) {
-    env.append("{ new(...args: any[]): ")
-    typeDef(env, item.typeParams[0])
-    env.append(" }")
+    return "{ new(...args: any[]): " + typeDef(env, item.typeParams[0]) + " }"
   } else {
-    otherDef(env, item)
+    return otherDef(env, item)
   }
 }

--- a/test/class.spec.ts
+++ b/test/class.spec.ts
@@ -1,96 +1,122 @@
-import {GenEnv, emptyEnvForTests} from "../src/env"
+import {emptyEnvForTests} from "../src/env"
 import {classDef} from "../src/gendeclaration";
 import {ClassOrInterfaceDeclaration} from "../src/types";
 
 describe('class definition', () => {
 
-  let env: GenEnv;
-  let cr = "\r\n";
-
-  beforeEach(function () {
-    env = emptyEnvForTests()
-  });
+  const env = emptyEnvForTests();
 
   it('should add class definition', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class" };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "}"
+    ])
   });
 
   it('should add class definition with generics', () => {
     const item: ClassOrInterfaceDeclaration= { type: "class", typeParams: [{ type: "Foo" }, { type: "Bar" }]};
-    classDef(env, item, "Class1");
-    env.sb.toString().should.equal("class Class1 <Foo, Bar> {" + cr + "}")
+    classDef(env, item, "Class1").should.deep.equal([
+      "class Class1<Foo, Bar> {",
+      "}"
+    ])
   });
 
   it('should not use return type for a constructor', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", constructor: { type: "Function", id: "Foo.constructor"} };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  constructor()" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  constructor()",
+      "}"
+    ])
   });
 
   it('should add class definition with one let property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", properties: { prop1: { type: "number" } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  prop1: number;" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  prop1: number;",
+      "}"
+    ])
   });
 
   it('should add class definition with one optional let property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", properties: { prop1: { type: "number", optional: true } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  prop1?: number | null;" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  prop1?: number | null;",
+      "}"
+    ])
   });
 
   it('should add class definition with one union property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", properties: { prop2: { type: "union", typeParams: [{type: "Node"}, {type: "Node2"}] } } };
-    classDef(env, item, "Class1");
-    env.sb.toString().should.equal("class Class1 {" + cr + "  prop2: Node | Node2;" + cr + "}")
+    classDef(env, item, "Class1").should.deep.equal([
+      "class Class1 {",
+      "  prop2: Node | Node2;",
+      "}"
+    ])
   });
 
   it('should add class definition with one function property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", properties: { prop1: { type: "Function", returns: { type: "any"}, params: [{name: "state", type: "EditorState"}] } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  prop1(state: EditorState): any" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  prop1(state: EditorState): any",
+      "}"
+    ])
   });
 
   it('should add interface definition with one optional function property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "interface", properties: { prop1: { type: "Function", optional: true, returns: { type: "any"}, params: [{name: "state", type: "EditorState"}] } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("interface Foo {" + cr + "  prop1?: ((state: EditorState) => any) | null;" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "interface Foo {",
+      "  prop1?: ((state: EditorState) => any) | null;",
+      "}"
+    ])
   });
 
   it('should add class definition with one static let property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", staticProperties: { prop1: { type: "number" } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  static prop1: number;" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  static prop1: number;",
+      "}"
+    ])
   });
 
   it('should add class definition with one static function property', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", staticProperties: { prop1: { type: "Function", returns: { type: "any" }, params: [{ name: "state", type: "EditorState" }] } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  static prop1(state: EditorState): any" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  static prop1(state: EditorState): any",
+      "}"
+    ])
   });
 
   it('should add class definition with two properties', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", properties: { prop1: { type: "number" } }, staticProperties: { prop2: { type: "Function", returns: { type: "any" }, params: [{ name: "state", type: "EditorState" }] } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal("class Foo {" + cr + "  prop1: number;" + cr + "  static prop2(state: EditorState): any" + cr + "}")
+    classDef(env, item, "Foo").should.deep.equal([
+      "class Foo {",
+      "  prop1: number;",
+      "  static prop2(state: EditorState): any",
+      "}"
+    ])
   });
 
   it('should add class definition with JSDoc comments', () => {
     const item: ClassOrInterfaceDeclaration = { type: "class", description: "Lorem ipsum", properties: { prop1: { description: "number of props given", type: "number", optional: true } } };
-    classDef(env, item, "Foo");
-    env.sb.toString().should.equal(
-      "/**" + cr +
-      " * Lorem ipsum" + cr +
-      " */" + cr +
-      "class Foo {" + cr +
-      "  /**" + cr +
-      "   * number of props given" + cr +
-      "   */" + cr +
-      "  prop1?: number | null;" + cr +
+    classDef(env, item, "Foo").should.deep.equal([
+      "/**",
+      " * Lorem ipsum",
+      " */",
+      "class Foo {",
+      "  /**",
+      "   * number of props given",
+      "   */",
+      "  prop1?: number | null;",
       "}"
-    )
+    ])
   })
 
 });

--- a/test/function.spec.ts
+++ b/test/function.spec.ts
@@ -1,16 +1,12 @@
-import {GenEnv, emptyEnvForTests} from "../src/env"
+import {emptyEnvForTests} from "../src/env"
 import {functionDef} from "../src/gentype";
 import {FunctionType, Parameter} from "../src/types";
 
-let env: GenEnv;
+const env = emptyEnvForTests();
 
 function mkFunction(...params: Parameter[]): FunctionType {
   return { type: "Function", params };
 }
-
-beforeEach(function () {
-  env = emptyEnvForTests()
-});
 
 describe('should add function definition', () => {
 
@@ -18,26 +14,22 @@ describe('should add function definition', () => {
 
     it('void', () => {
       let item = mkFunction();
-      functionDef(env, item);
-      env.sb.toString().should.equal("() => void")
+      functionDef(env, item).should.equal("() => void")
     });
 
     it('should handle optional bool return type', () => {
       const item: FunctionType = { type: "Function", params: [], returns: { type: "bool", optional: true } }
-      functionDef(env, item);
-      env.sb.toString().should.equal("() => boolean | null | undefined")
+      functionDef(env, item).should.equal("() => boolean | null | undefined")
     })
 
     it('should handle optional function return type', () => {
       const item: FunctionType = { type: "Function", params: [], returns: { type: "union", optional: true, typeParams: [{ type: "string" }, { type: "Function", params: [] }] } }
-      functionDef(env, item);
-      env.sb.toString().should.equal("() => string | (() => void) | null | undefined")
+      functionDef(env, item).should.equal("() => string | (() => void) | null | undefined")
     })
 
     it('Object', () => {
       const item: FunctionType = { type: "Function", params: [], returns: { type: "Object" } }
-      functionDef(env, item);
-      env.sb.toString().should.equal("() => { [key: string]: any }")
+      functionDef(env, item).should.equal("() => { [key: string]: any }")
     });
 
   });
@@ -46,56 +38,47 @@ describe('should add function definition', () => {
 
     it('one named parameter', () => {
       const item = mkFunction({ type: "bool", name: "param1" })
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1: boolean) => void")
+      functionDef(env, item).should.equal("(param1: boolean) => void")
     });
 
     it('one optional named parameter', () => {
       const item = mkFunction({ type: "bool", name: "param1", optional: true })
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1?: boolean) => void")
+      functionDef(env, item).should.equal("(param1?: boolean) => void")
     });
 
     it('two named parameters', () => {
       const item = mkFunction({ type: "bool", name: "param1" }, { type: "Object", name: "param2" })
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1: boolean, param2: { [key: string]: any }) => void")
+      functionDef(env, item).should.equal("(param1: boolean, param2: { [key: string]: any }) => void")
     });
 
     it('two optional named parameters', () => {
       const item = mkFunction({ type: "bool", name: "param1", optional: true }, { type: "number", name: "param2", optional: true })
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1?: boolean, param2?: number) => void")
+      functionDef(env, item).should.equal("(param1?: boolean, param2?: number) => void")
     });
 
     it('an optional parameter followed by a normal parameter', () => {
       const item = mkFunction({ type: "bool", name: "param1", optional: true }, { type: "number", name: "param2" })
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1: boolean | undefined, param2: number) => void")
+      functionDef(env, item).should.equal("(param1: boolean | undefined, param2: number) => void")
     })
 
     it('rest parameter', () => {
       const item = mkFunction({ type: "bool", name: "param1", rest: true });
-      functionDef(env, item);
-      env.sb.toString().should.equal("(...param1: boolean) => void")
+      functionDef(env, item).should.equal("(...param1: boolean) => void")
     });
 
     it('array with function parameter', () => {
       const item = mkFunction({ type: "Array", name: "param1", typeParams: [{type: "Function", params: []}] })
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1: (() => void)[]) => void")
+      functionDef(env, item).should.equal("(param1: (() => void)[]) => void")
     });
 
     it('function parameter', () => {
       const item = mkFunction({ type: "Function", params: [], name: "param1" });
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1: () => void) => void")
+      functionDef(env, item).should.equal("(param1: () => void) => void")
     });
 
     it('optional function parameter', () => {
       const item = mkFunction({ type: "Function", params: [], name: "param1", optional: true });
-      functionDef(env, item);
-      env.sb.toString().should.equal("(param1?: () => void) => void")
+      functionDef(env, item).should.equal("(param1?: () => void) => void")
     });
 
   });

--- a/test/item.spec.ts
+++ b/test/item.spec.ts
@@ -1,50 +1,39 @@
-import {GenEnv, emptyEnvForTests} from "../src/env"
+import {emptyEnvForTests} from "../src/env"
 import {itemDef} from "../src/gendeclaration";
 
 
-let env: GenEnv;
-let cr = "\r\n";
-
-beforeEach(function () {
-  env = emptyEnvForTests();
-});
+const env = emptyEnvForTests();
 
 describe('should add item definition', () => {
   it('should create a class', () => {
     let item = { type: "class" };
-    itemDef(env, item, "Plugin");
-    env.sb.toString().should.equal('class Plugin {' + cr + "}")
+    itemDef(env, item, "Plugin").should.deep.equal(['class Plugin {',"}"])
   });
   it('should create a interface', () => {
     let item = { type: "interface" };
-    itemDef(env, item, "Plugin");
-    env.sb.toString().should.equal('interface Plugin {' + cr + "}")
+    itemDef(env, item, "Plugin").should.deep.equal(['interface Plugin {',"}"])
   });
 
   it('should create an object', () => {
     let item = { type: "Object", properties: { props: {type: "EditorProps", optional: true}} };
-    itemDef(env, item, "PluginSpec");
-    env.sb.toString().should.equal("let PluginSpec: { props?: EditorProps | null }")
+    itemDef(env, item, "PluginSpec").should.deep.equal(["let PluginSpec: { props?: EditorProps | null }"])
   });
 
   it('should handle a function', () => {
     let item = { type: "Function", params: [] };
-    itemDef(env, item, "testFoo");
-    env.sb.toString().should.equal("function testFoo(): void")
+    itemDef(env, item, "testFoo").should.deep.equal(["function testFoo(): void"])
   })
 
   it('should handle an optional function', () => {
     let item = { type: "Function", optional: true, params: [] };
-    itemDef(env, item, "testFoo");
-    env.sb.toString().should.equal("let testFoo: (() => void) | null | undefined")
+    itemDef(env, item, "testFoo").should.deep.equal(["let testFoo: (() => void) | null | undefined"])
   });
 
   it('should allow using custom code for some definitions', () => {
     let item = { type: "interface" };
     const code = 'export type DOMOutputSpec = string | Node'
-    env = emptyEnvForTests({ DOMOutputSpec: { code } });
-    itemDef(env, item, "DOMOutputSpec");
-    env.sb.toString().should.equal(code)
+    const customEnv = emptyEnvForTests({ DOMOutputSpec: { code } });
+    itemDef(customEnv, item, "DOMOutputSpec").should.deep.equal([code])
   });
 
 });

--- a/test/misc.spec.ts
+++ b/test/misc.spec.ts
@@ -1,32 +1,30 @@
-import {GenEnv, emptyEnvForTests} from "../src/env"
+import {emptyEnvForTests} from "../src/env"
 import {miscDef} from "../src/gendeclaration";
 
 
-let env: GenEnv;
-let cr = "\r\n";
-
-beforeEach(function () {
-  env = emptyEnvForTests()
-});
+const env = emptyEnvForTests();
 
 describe('when adding misc module definition', () => {
 
   it('should create a constructor', () => {
     let item = {id: "Plugin.constructor", name: "Plugin", type: "Function"};
-    miscDef(env, item, "item1", { isInlineProp: false });
-    env.sb.toString().should.equal('constructor()')
+    miscDef(env, item, "item1", { isInlineProp: false }).should.deep.equal([
+      'constructor()'
+    ])
   });
 
   it('should create a constructor with one parameter', () => {
     let item = { id: "Plugin.constructor", name: "Plugin", type: "Function", params: [{name: "spec", type: "PluginSpec"}] };
-    miscDef(env, item, "item1", { isInlineProp: false });
-    env.sb.toString().should.equal('constructor(spec: PluginSpec)')
+    miscDef(env, item, "item1", { isInlineProp: false }).should.deep.equal([
+      'constructor(spec: PluginSpec)'
+    ])
   });
 
   it('should create a constructor with two parameter', () => {
     let item = { id: "Plugin.constructor", name: "Plugin", type: "Function", params: [{ name: "spec", type: "PluginSpec" }, { name: "spec2", type: "number" }] };
-    miscDef(env, item, "item1", { isInlineProp: false });
-    env.sb.toString().should.equal('constructor(spec: PluginSpec, spec2: number)')
+    miscDef(env, item, "item1", { isInlineProp: false }).should.deep.equal([
+      'constructor(spec: PluginSpec, spec2: number)'
+    ])
   });
 
 

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -1,27 +1,30 @@
 import moduleDef from "../src/genmodule";
 
 
-let cr = "\r\n";
-
 describe('when adding module definition', () => {
 
   it('should create an empty module', () => {
     let module = {};
-    let sb = moduleDef(module, "module1", {});
-    sb.toString().should.equal('')
+    moduleDef(module, "module1", {}).should.deep.equal([])
   });
 
   it('should create an module with one item', () => {
     let module = { items: {Class1: { type: "class"}} };
-    let sb = moduleDef(module, "module1", {});
-    sb.toString().should.equal('export class Class1 {' + cr + '}')
+    moduleDef(module, "module1", {}).should.deep.equal([
+      "export class Class1 {",
+      "}"
+    ])
   });
 
   it('should replace additional type', () => {
     let module = { items: { RedNode: { type: "class", extends: { type: "Node" } }} };
     let additionalTypes = { "Node": { replaceBy: "ProsemirrorNode", definedIn: "prosemirror-model" }};
-    let sb = moduleDef(module, "module1", additionalTypes);
-    sb.toString().should.equal('import { ProsemirrorNode } from \'prosemirror-model\';' + cr + cr + 'export class RedNode extends ProsemirrorNode {' + cr + '}')
+    moduleDef(module, "module1", additionalTypes).should.deep.equal([
+      "import { ProsemirrorNode } from 'prosemirror-model';",
+      "",
+      "export class RedNode extends ProsemirrorNode {",
+      "}"
+    ])
   });
 
 });

--- a/test/object.spec.ts
+++ b/test/object.spec.ts
@@ -1,18 +1,13 @@
-import {GenEnv, emptyEnvForTests} from "../src/env"
+import {emptyEnvForTests} from "../src/env"
 import {objectDef} from "../src/gentype";
 import {ObjectType} from "../src/types";
 
-let env: GenEnv;
-
-beforeEach(function () {
-  env = emptyEnvForTests();
-});
+const env = emptyEnvForTests();
 
 describe('should add object definition', () => {
   it('with one property', () => {
     const item: ObjectType = { type: "Object", properties: { prop1: { type: "string" } } };
-    objectDef(env, item);
-    env.sb.toString().should.equal("{ prop1: string }")
+    objectDef(env, item).should.equal("{ prop1: string }")
   });
 
   it('with two properties', () => {
@@ -20,7 +15,6 @@ describe('should add object definition', () => {
       type: "Object",
       properties: { prop1: { type: "string" }, prop2: { type: "Object" } }
     };
-    objectDef(env, item);
-    env.sb.toString().should.equal("{ prop1: string, prop2: { [key: string]: any } }")
+    objectDef(env, item).should.equal("{ prop1: string, prop2: { [key: string]: any } }")
   });
 });

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -3,7 +3,7 @@
 import * as chai from 'chai';
 // import chaiAsPromised = require('chai-as-promised');
 import * as chaiAsPromised from 'chai-as-promised';
-import * as sinon from 'sinon';
+//import * as sinon from 'sinon';
 
 before(function () {
   chai.should();

--- a/test/test-setup.ts
+++ b/test/test-setup.ts
@@ -1,12 +1,6 @@
-
-// import chai = require('chai');
 import * as chai from 'chai';
-// import chaiAsPromised = require('chai-as-promised');
-import * as chaiAsPromised from 'chai-as-promised';
-//import * as sinon from 'sinon';
 
 before(function () {
   chai.should();
-  chai.use(chaiAsPromised);
 });
 

--- a/test/type.spec.ts
+++ b/test/type.spec.ts
@@ -1,10 +1,9 @@
 import {emptyEnvForTests} from "../src/env"
 import {typeDef} from "../src/gentype";
 
-
-const env = emptyEnvForTests();
-
 describe('when adding type definition', () => {
+
+  const env = emptyEnvForTests();
 
   it('should handle a function', () => {
     const item = { type: "Function", params: [] };

--- a/test/type.spec.ts
+++ b/test/type.spec.ts
@@ -1,128 +1,105 @@
-import {GenEnv, emptyEnvForTests} from "../src/env"
+import {emptyEnvForTests} from "../src/env"
 import {typeDef} from "../src/gentype";
 
 
-let env: GenEnv;
-
-beforeEach(function () {
-  env = emptyEnvForTests();
-});
+const env = emptyEnvForTests();
 
 describe('when adding type definition', () => {
 
   it('should handle a function', () => {
     const item = { type: "Function", params: [] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("() => void")
+    typeDef(env, item).should.equal("() => void")
   });
 
   it('should handle an array with one type param', () => {
     const item = { type: "Array", typeParams: [{ type: "string" }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("string[]")
+    typeDef(env, item).should.equal("string[]")
   });
 
   it('should handle an empty union', () => {
     const item = { type: "union", typeParams: [] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("never")
+    typeDef(env, item).should.equal("never")
   })
 
   it('should handle a union with one type param', () => {
     const item = { type: "union", typeParams: [{ type: "string" }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("string")
+    typeDef(env, item).should.equal("string")
   });
 
   it('should handle a union with one function type param', () => {
     const item = { type: "union", typeParams: [{ type: "Function", params: [{type: "string"}] }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("(p: string) => void")
+    typeDef(env, item).should.equal("(p: string) => void")
   })
 
   it('should handle a union with two type params', () => {
     const item = { type: "union", typeParams: [{ type: "number" }, { type: "string" }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("number | string")
+    typeDef(env, item).should.equal("number | string")
   });
 
   it('should handle a union with one array type param', () => {
     const item = { type: "union", typeParams: [{ type: "Array", typeParams: [{type: "Node"}] }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("Node[]")
+    typeDef(env, item).should.equal("Node[]")
   });
 
   it('should handle a union with one number param and one function', () => {
     const item = { type: "union", typeParams: [{ type: "number" }, { type: "Function", params: [{type: "string"}] }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("number | ((p: string) => void)")
+    typeDef(env, item).should.equal("number | ((p: string) => void)")
   });
 
   it('should handle a union with one number param and one function with two params', () => {
     const item = { type: "union", typeParams: [{ type: "number" }, { type: "Function", params: [{ type: "string" }, { type: "string" }] }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("number | ((p1: string, p2: string) => void)")
+    typeDef(env, item).should.equal("number | ((p1: string, p2: string) => void)")
   });
 
   it('should handle an array of unions', () => {
     const item = { type: "Array", typeParams: [{ type: "union", typeParams: [{ type: "number" }, { type: "bool" }] }] };
-    typeDef(env, item);
-    env.sb.toString().should.equal("(number | boolean)[]")
+    typeDef(env, item).should.equal("(number | boolean)[]")
   });
 
   it('should handle an object with unknown properties', () => {
     const item = { type: "Object", };
-    typeDef(env, item);
-    env.sb.toString().should.equal("{ [key: string]: any }")
+    typeDef(env, item).should.equal("{ [key: string]: any }")
   });
 
   it('should handle objects with a known value type', () => {
     const item = { type: "Object", typeParams: [{ type: "bool" }] }
-    typeDef(env, item)
-    env.sb.toString().should.equal("{ [name: string]: boolean }")
+    typeDef(env, item).should.equal("{ [name: string]: boolean }")
   })
 
   it('should handle string', () => {
     let item = { type: "string" };
-    typeDef(env, item);
-    env.sb.toString().should.equal("string")
+    typeDef(env, item).should.equal("string")
   });
 
   it('should handle bool', () => {
     let item = { type: "bool" };
-    typeDef(env, item);
-    env.sb.toString().should.equal("boolean")
+    typeDef(env, item).should.equal("boolean")
   });
 
   it('should handle string singleton types', () => {
     const item = { type: '"foo"' };
-    typeDef(env, item);
-    env.sb.toString().should.equal('"foo"')
+    typeDef(env, item).should.equal('"foo"')
   })
 
   it('should handle other with one type param', () => {
     const item = { type: "MyType", typeParams: [{name: "typeParam1", type: "string" }]};
-    typeDef(env, item);
-    env.sb.toString().should.equal("MyType<string>")
+    typeDef(env, item).should.equal("MyType<string>")
   });
 
   it('should handle other with two type params', () => {
     const item = { type: "MyType", typeParams: [{ name: "typeParam1", type: "string" }, { name: "typeParam2", type: "number" }]};
-    typeDef(env, item);
-    env.sb.toString().should.equal("MyType<string, number>")
+    typeDef(env, item).should.equal("MyType<string, number>")
   });
 
   it('should handle ', () => {
     const item = { type: "constructor", typeParams: [{ type: "Foo" }] }
-    typeDef(env, item);
-    env.sb.toString().should.equal("{ new(...args: any[]): Foo }")
+    typeDef(env, item).should.equal("{ new(...args: any[]): Foo }")
   });
 
   describe('when type is unknown', () => {
     it('should replace type', () => {
       const item = { type: "MyType", typeParams: [{ name: "typeParam1", type: "string" }, { name: "typeParam2", type: "number" }] };
-      typeDef(env, item);
-      env.sb.toString().should.equal("MyType<string, number>")
+      typeDef(env, item).should.equal("MyType<string, number>")
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "out",
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
     "declaration": true
   },
   "include": [


### PR DESCRIPTION
This solves #13. This change makes the code more concise (as evidenced by the code size decrease of ~100 lines) and less stateful.

There is no performance penalty: On my computer, the running time of the test suite has even decreased from ~80ms to ~60ms. The time needed for generating the ProseMirror bindings has stayed the same (about 0.8 seconds).