### PR TITLE
Add link to getdocs project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # getdocs2ts
 
-This is a utility that transforms code documented with getdocs-style doc comments into TypeScript definition files
+This is a utility that transforms code documented with [getdocs][]-style doc comments into TypeScript definition files
+
+[getdocs]: https://github.com/marijnh/getdocs
 
 # Usage
 


### PR DESCRIPTION
Hello! I got here because I was looking at the (awesome) type annotations for ProseMirror, and they mentioned that they were auto-generated with this (awesome) tool.  However, I didn't know what "getdocs" was, and doing a google search was actually a bit unclear because the correct result was a few entries down. So I thought it might make things easier if the readme linked to the project.

Thanks for making this tool, by the way!
